### PR TITLE
Invalid old orb caches

### DIFF
--- a/src/jobs/deploy.yml
+++ b/src/jobs/deploy.yml
@@ -13,7 +13,7 @@ parameters:
   # prepare-trellis
   cache-version:
     type: string
-    default: v5
+    default: v6
     description: Change the default cache version if you need to clear the cache for any reason
   trellis-repo:
     type: string


### PR DESCRIPTION
https://github.com/roots/trellis/pull/1222#issuecomment-697116777


```
#!/bin/bash -eo pipefail
trellis exec pip3 install --upgrade --upgrade-strategy eager -r requirements.txt

Collecting ansible<3.0,>=2.8.0
  Downloading ansible-2.10.0.tar.gz (25.5 MB)
     |████████████████████████████████| 25.5 MB 12.8 MB/s eta 0:00:0111
    ERROR: Command errored out with exit status 1:
     command: /home/circleci/project/trellis/.trellis/virtualenv/bin/python -c 'import sys, setuptools, tokenize; sys.argv[0] = '"'"'/tmp/pip-install-6_qvflzq/ansible/setup.py'"'"'; __file__='"'"'/tmp/pip-install-6_qvflzq/ansible/setup.py'"'"';f=getattr(tokenize, '"'"'open'"'"', open)(__file__);code=f.read().replace('"'"'\r\n'"'"', '"'"'\n'"'"');f.close();exec(compile(code, __file__, '"'"'exec'"'"'))' egg_info --egg-base /tmp/pip-pip-egg-info-1pec1urg
         cwd: /tmp/pip-install-6_qvflzq/ansible/
    Complete output (31 lines):
    
    
                ### ERROR ###
    
                Upgrading directly from ansible-2.9 or less to ansible-2.10 or greater with pip is
                known to cause problems.  Please uninstall the old version found at:
    
                /home/circleci/project/trellis/.trellis/virtualenv/lib/python3.8/site-packages/ansible/__init__.py
    
                and install the new version:
    
                    pip uninstall ansible
                    pip install ansible
    
                If you have a broken installation, perhaps because ansible-base was installed before
                ansible was upgraded, try this to resolve it:
    
                    pip install --force-reinstall ansible ansible-base
    
                If ansible is installed in a different location than you will be installing it now
                (for example, if the old version is installed by a system package manager to
                /usr/lib/python3.8/site-packages/ansible but you are installing the new version into
                ~/.local/lib/python3.8/site-packages/ansible with `pip install --user ansible`)
                or you want to install anyways and cleanup any breakage afterwards, then you may set
                the ANSIBLE_SKIP_CONFLICT_CHECK environment variable to ignore this check:
    
                    ANSIBLE_SKIP_CONFLICT_CHECK=1 pip install --user ansible
    
                ### END ERROR ###
    
    
    ----------------------------------------
ERROR: Command errored out with exit status 1: python setup.py egg_info Check the logs for full command output.
WARNING: You are using pip version 20.1.1; however, version 20.2.3 is available.
You should consider upgrading via the '/home/circleci/project/trellis/.trellis/virtualenv/bin/python -m pip install --upgrade pip' command.
```