### PR TITLE
Bump `cache-version` to v9

### DIFF
--- a/src/jobs/deploy.yml
+++ b/src/jobs/deploy.yml
@@ -13,7 +13,7 @@ parameters:
   # prepare-trellis
   cache-version:
     type: string
-    default: v8
+    default: v9
     description: Change the default cache version if you need to clear the cache for any reason
   trellis-repo:
     type: string


### PR DESCRIPTION
Same as https://github.com/ItinerisLtd/tiller-circleci-orb/pull/18