### PR TITLE
Add double cache key; Align `cache-version` in both job and command

### DIFF
--- a/src/commands/prepare_trellis.yml
+++ b/src/commands/prepare_trellis.yml
@@ -3,7 +3,7 @@ description: Clone the Trellis repo, set up ansible vault password and install a
 parameters:
   cache-version:
     type: string
-    default: v5
+    default: v9
     description: Change the default cache version if you need to clear the cache for any reason
   trellis-repo:
     type: string
@@ -28,9 +28,9 @@ steps:
       working_directory: trellis
   - restore_cache:
       keys:
-        - tiller-circleci-prepare-trellis-<< parameters.cache-version >>-{{ .Branch }}-{{ .Revision }}-
-        - tiller-circleci-prepare-trellis-<< parameters.cache-version >>-{{ .Branch }}-
-        - tiller-circleci-prepare-trellis-<< parameters.cache-version >>-
+        - tiller-circleci-prepare-trellis-o1-<< parameters.cache-version >>-{{ .Branch }}-{{ .Revision }}-
+        - tiller-circleci-prepare-trellis-o1-<< parameters.cache-version >>-{{ .Branch }}-
+        - tiller-circleci-prepare-trellis-o1-<< parameters.cache-version >>-
   - run:
       name: Set ansible vault password
       command: echo ${<< parameters.vault-password >>} > << parameters.vault-password-file-name >>
@@ -49,7 +49,7 @@ steps:
       command: trellis galaxy install
       working_directory: trellis
   - save_cache:
-      key: tiller-circleci-prepare-trellis-<< parameters.cache-version >>-{{ .Branch }}-{{ .Revision }}-{{ epoch }}
+      key: tiller-circleci-prepare-trellis-o1-<< parameters.cache-version >>-{{ .Branch }}-{{ .Revision }}-{{ epoch }}
       paths:
         - /tmp/trellis
         - ~/.cache


### PR DESCRIPTION
So that the cache can be invalidated by both orb users and orb authors .