### PR TITLE
`prepare_trellis`: Remove `restore_cache`

### DIFF
--- a/src/commands/prepare_trellis.yml
+++ b/src/commands/prepare_trellis.yml
@@ -26,11 +26,6 @@ steps:
       name: Clone Trellis repo
       command: git clone --verbose --branch << parameters.trellis-branch >> --depth 1 << parameters.trellis-repo >> .
       working_directory: trellis
-  - restore_cache:
-      keys:
-        - tiller-circleci-prepare-trellis-o1-<< parameters.cache-version >>-{{ .Branch }}-{{ .Revision }}-
-        - tiller-circleci-prepare-trellis-o1-<< parameters.cache-version >>-{{ .Branch }}-
-        - tiller-circleci-prepare-trellis-o1-<< parameters.cache-version >>-
   - run:
       name: Set ansible vault password
       command: echo ${<< parameters.vault-password >>} > << parameters.vault-password-file-name >>


### PR DESCRIPTION
Because @itinerisltd has trouble with caches:

```sh-session
#!/bin/bash -eo pipefail
trellis init

Creating virtualenv in /home/circleci/project/trellis/.trellis/virtualenv
Error creating virtualenv: exit status 1

Exited with code exit status 1

CircleCI received exit code 1
```